### PR TITLE
Add SQLite logging tests and example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENROUTER_API_KEY=your_openrouter_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .env
+
+__pycache__/
+venv/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Diego Colín
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ pip install -r requirements.txt
 ### Environment Configuration
 
 ```env
+# Copy .env.example to .env and add your key
 OPENROUTER_API_KEY=your_openrouter_key_here
 ```
 
@@ -81,13 +82,21 @@ curl -X POST https://your-backend-url/ask \
 -d "{\"question\": \"¿Qué hacer si hay alerta de huracán?\"}"
 ```
 
+### Running Tests
+
+```bash
+pytest
+```
+
 ---
 
 <div align="center">
 
 **[📝 Documentation](https://github.com/DiegoCM1/ai-blueye/wiki)** • 
-**[🐛 Issues](https://github.com/DiegoCM1/ai-blueye/issues)** • 
+**[🐛 Issues](https://github.com/DiegoCM1/ai-blueye/issues)** •
 **[📫 Contact](mailto:your-email@domain.com)**
+
+Released under the [MIT License](LICENSE).
 
 </div>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.29.0
 httpx==0.28.1
 python-dotenv==1.0.1
 aiosqlite==0.20.0
+pytest==8.2.0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,45 @@
+import os
+import sqlite3
+import tempfile
+from fastapi.testclient import TestClient
+
+# Set environment variable before importing main
+os.environ.setdefault("OPENROUTER_API_KEY", "test-key")
+
+import main
+from unittest.mock import AsyncMock
+
+
+class MockResponse:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+
+
+def create_client(tmp_path):
+    # use temporary database
+    db_file = tmp_path / "test.db"
+    main.DB_PATH = str(db_file)
+
+    async def mock_post(self, url, headers=None, json=None):
+        return MockResponse({"choices": [{"message": {"content": "mocked"}}]})
+
+    # patch httpx.AsyncClient.post
+    main.httpx.AsyncClient.post = AsyncMock(side_effect=mock_post)
+
+    return TestClient(main.app)
+
+
+def test_ask_endpoint(tmp_path):
+    client = create_client(tmp_path)
+    with client:
+        response = client.post("/ask", json={"question": "hello"})
+        assert response.status_code == 200
+        assert response.json()["response"] == "mocked"
+
+    # verify question stored in database
+    conn = sqlite3.connect(main.DB_PATH)
+    row = conn.execute("SELECT question FROM prompts").fetchone()
+    conn.close()
+    assert row[0] == "hello"


### PR DESCRIPTION
## Summary
- ignore common virtualenv and pycache folders
- add MIT license and environment template
- document setup & testing steps
- add pytest-based test for `/ask` endpoint
- install pytest in dependencies

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6875ccfc694c833181d9199097358b02