### PR TITLE
Add user tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ An award-winning AI-powered hurricane safety assistant built with **FastAPI** an
 - 🤖 **Advanced AI Models**
   - LLaMA 3.3 8B Instruct
   - LLaMA 4 Scout
+- 📝 **Prompt Logging**
+  - Stores questions, AI answers, and client IP addresses in SQLite
 
 ## 🛠️ Technologies
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,7 +40,8 @@ def test_ask_endpoint(tmp_path):
 
     # verify question and answer stored in database
     conn = sqlite3.connect(main.DB_PATH)
-    row = conn.execute("SELECT question, answer FROM prompts").fetchone()
+    row = conn.execute("SELECT question, answer, user FROM prompts").fetchone()
     conn.close()
     assert row[0] == "hello"
     assert row[1] == "mocked"
+    assert row[2] == "testclient"


### PR DESCRIPTION
## Summary
- track requester IP in prompts table
- adjust ask endpoint to save IP
- update tests for new column
- mention prompt logging in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687679e8b6e883319a95e8c3a70164ad