### PR TITLE
Fix database path to be script-relative

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 import httpx
 from dotenv import load_dotenv
 import os
+import os.path
 from fastapi.middleware.cors import CORSMiddleware
 import aiosqlite
 
@@ -27,7 +28,8 @@ app.add_middleware(
 
 
 # ✅ Database initialization
-DB_PATH = "prompts.db"
+DB_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                       "prompts.db")
 
 
 @app.on_event("startup")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,47 +1,66 @@
 import os
 import sqlite3
-import tempfile
+import importlib
 from fastapi.testclient import TestClient
-
-# Set environment variable before importing main
-os.environ.setdefault("OPENROUTER_API_KEY", "test-key")
-
-import main
 from unittest.mock import AsyncMock
+
+os.environ.setdefault("OPENROUTER_API_KEY", "test-key")
 
 
 class MockResponse:
     def __init__(self, data):
         self._data = data
+
     def json(self):
         return self._data
 
 
-def create_client(tmp_path):
-    # use temporary database
-    db_file = tmp_path / "test.db"
-    main.DB_PATH = str(db_file)
+def reload_main():
+    import main
+    return importlib.reload(main)
+
+
+def create_client(main_module, db_path):
+    main_module.DB_PATH = str(db_path)
 
     async def mock_post(self, url, headers=None, json=None):
         return MockResponse({"choices": [{"message": {"content": "mocked"}}]})
 
-    # patch httpx.AsyncClient.post
-    main.httpx.AsyncClient.post = AsyncMock(side_effect=mock_post)
-
-    return TestClient(main.app)
+    main_module.httpx.AsyncClient.post = AsyncMock(side_effect=mock_post)
+    return TestClient(main_module.app)
 
 
 def test_ask_endpoint(tmp_path):
-    client = create_client(tmp_path)
+    main = reload_main()
+    client = create_client(main, tmp_path / "test.db")
     with client:
         response = client.post("/ask", json={"question": "hello"})
         assert response.status_code == 200
         assert response.json()["response"] == "mocked"
 
-    # verify question and answer stored in database
     conn = sqlite3.connect(main.DB_PATH)
     row = conn.execute("SELECT question, answer, user FROM prompts").fetchone()
     conn.close()
     assert row[0] == "hello"
     assert row[1] == "mocked"
     assert row[2] == "testclient"
+
+
+def test_db_path_from_other_cwd(tmp_path):
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        main = reload_main()
+        expected = os.path.join(os.path.dirname(os.path.abspath(main.__file__)), "prompts.db")
+        assert main.DB_PATH == expected
+
+        client = create_client(main, tmp_path / "alt.db")
+        with client:
+            resp = client.post("/ask", json={"question": "cwd"})
+            assert resp.status_code == 200
+
+        assert os.path.exists(main.DB_PATH)
+    finally:
+        os.chdir(old_cwd)
+        reload_main()
+


### PR DESCRIPTION
## Summary
- ensure `os.path` is imported
- store prompts in a database located next to `main.py`
- rework tests to reload `main` and verify DB location when cwd changes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687680d862248331b227bb0af38c7477